### PR TITLE
fix: presentation of score column

### DIFF
--- a/src/ScoreColumn.tsx
+++ b/src/ScoreColumn.tsx
@@ -13,7 +13,7 @@ const ScoreColumn: Component<ShowScoreProps> = ({ showScore }) => {
   const handleAddScore = () => {
     const parsedScore = parseInt(nextScore(), 10);
     if (!isNaN(parsedScore)) {
-      setAllScores([...allScores(), parsedScore]);
+      setAllScores([parsedScore, ...allScores()]);
       setNextScore("");
     } else {
       setIsInputValid(false);
@@ -21,8 +21,8 @@ const ScoreColumn: Component<ShowScoreProps> = ({ showScore }) => {
   };
 
   const handleRemoveLast = () => {
-    const newScores = [...allScores()];
-    newScores.pop();
+    let newScores = [...allScores()];
+    newScores = newScores.slice(1);
     setAllScores(newScores);
   };
 
@@ -63,10 +63,6 @@ const ScoreColumn: Component<ShowScoreProps> = ({ showScore }) => {
         <div class="text-xl font-bold mt-2">Total Score: {totalScore()}</div>
       </Show>
 
-      <For each={allScores()}>
-        {(score) => <div data-testid="score-item">{score}</div>}
-      </For>
-
       <div class="mt-3">
         <button
           class="border border-black bg-gray-200 rounded-md px-2 py-1"
@@ -76,6 +72,10 @@ const ScoreColumn: Component<ShowScoreProps> = ({ showScore }) => {
           remove last
         </button>
       </div>
+
+      <For each={allScores()}>
+        {(score) => <div data-testid="score-item">{score}</div>}
+      </For>
     </div>
   );
 };


### PR DESCRIPTION
The score column is now reverted, last added score is on top. Previously, added scores were very likely out of view. Also, the remove-last button stays on top.